### PR TITLE
Fix a halfedges race condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,9 @@ function Delaunator(points, getX, getY) {
 
         // recursively flip triangles from the point until they satisfy the Delaunay condition
         e.t = this._legalize(t + 2);
+        if (e.prev.prev.t === halfedges[t + 1]) {
+            e.prev.prev.t = t + 2;
+        }
 
         // walk forward through the hull, adding more triangles and flipping recursively
         var q = e.next;

--- a/test.js
+++ b/test.js
@@ -15,6 +15,14 @@ test('triangulates points', function (t) {
 });
 
 test('produces properly connected halfedges', function (t) {
+    testHalfedges(t, points);
+});
+
+test('issue #11', function (t) {
+    testHalfedges(t, [[516, 661], [369, 793], [426, 539], [273, 525], [204, 694], [747, 750], [454, 390]]);
+});
+
+function testHalfedges(t, points) {
     var d = new Delaunator(points);
     for (var i = 0; i < d.halfedges.length; i++) {
         var i2 = d.halfedges[i];
@@ -24,7 +32,7 @@ test('produces properly connected halfedges', function (t) {
     }
     t.pass('halfedges are valid');
     t.end();
-});
+}
 
 test('throws on small number of points', function (t) {
     t.throws(function () {


### PR DESCRIPTION
Closes #11. cc @redblobgames 

Not the most elegant fix but should do the trick. The bug was in the way I tracked halfedge ids associated with convex hull's edges — when an opposing edge of a flipped quad also belonged to the convex hull (usually in the very beginning of a triangulation), flipping would invalidate the associated adjacent edge id of that edge.