### PR TITLE
Adopt UMD with default export.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
-'use strict';
-
-module.exports = Delaunator;
-module.exports.default = Delaunator;
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+  typeof define === 'function' && define.amd ? define(factory) :
+  (global.Delaunator = factory());
+}(this, (function () { 'use strict';
 
 function Delaunator(points, getX, getY) {
 
@@ -439,3 +440,7 @@ function defaultGetX(p) {
 function defaultGetY(p) {
     return p[1];
 }
+
+return Delaunator;
+
+})));


### PR DESCRIPTION
Adopting UMD enables this library to be loaded in a browser without needing to define a global `window.modules = {}` first (and without leaking globals like `dist`, `area` *etc.*).

```html
<script src="https://unpkg.com/delaunator"></script>
<script>

console.log(Delaunator); // Hooray!

</script>
```

It also allows the library to be loaded by an AMD loader such as RequireJS and d3-require.

```js
<script src="https://unpkg.com/d3-require"></script>
<script>

d3.require("delaunator").then(function(Delaunator) {
  console.log(Delaunator); // Hooray!
});

</script>
```

And of course it retains compatibility with CommonJS.

```js
var Delaunator = require("delaunator");
```

The specific UMD pattern here is copied from [Rollup](https://rollupjs.org). If you prefer, I’d be willing to expand this PR to rewrite this library as ES modules, and then use Rollup to generate the UMD (and any other bundle format) automatically. That would make this library easier to consume in environments that support ES modules.

Note that this doesn’t pass the tests: for readability purposes, I didn’t indent the code inside the surrounding factory function. The ESLint configuration here prevents you from using the UMD pattern, since the "use strict" goes inside the factory function. I figured I would send this along for review so you can suggest how you’d like this fixed.

Thanks for the great library!