### PR TITLE
Allow plain arrays.

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ export default class Delaunator {
         const n = coords.length >> 1;
         const ids = this.ids = new Uint32Array(n);
 
+        if (n > 0 && typeof coords[0] !== 'number') throw new Error('Expected coords to contain numbers.');
+
         this.coords = coords;
 
         for (let i = 0; i < n; i++) {

--- a/index.js
+++ b/index.js
@@ -18,8 +18,6 @@ export default class Delaunator {
     }
 
     constructor(coords) {
-        if (!ArrayBuffer.isView(coords)) throw new Error('Expected coords to be a typed array.');
-
         let minX = Infinity;
         let minY = Infinity;
         let maxX = -Infinity;

--- a/test.js
+++ b/test.js
@@ -26,10 +26,12 @@ test('triangulates typed array', function (t) {
 });
 
 test('constructor errors on invalid array', function (t) {
-    t.throws(function (t) {
-        const d = new Delaunator({length: -1});
-        t.ok(d);
-    });
+    t.throws(function () {
+        new Delaunator({length: -1});
+    }, /Invalid typed array length/);
+    t.throws(function () {
+        new Delaunator(points);
+    }, /Expected coords to contain numbers/);
     t.end();
 });
 

--- a/test.js
+++ b/test.js
@@ -13,9 +13,21 @@ test('triangulates points', function (t) {
     t.end();
 });
 
-test('constructor errors on non-typed array', function (t) {
+test('triangulates plain array', function (t) {
+    const d = new Delaunator([].concat.apply([], points));
+    t.same(Array.from(d.triangles), triangles);
+    t.end();
+});
+
+test('triangulates typed array', function (t) {
+    const d = new Delaunator(Float64Array.from([].concat.apply([], points)));
+    t.same(Array.from(d.triangles), triangles);
+    t.end();
+});
+
+test('constructor errors on invalid array', function (t) {
     t.throws(function (t) {
-        const d = new Delaunator(points);
+        const d = new Delaunator({length: -1});
         t.ok(d);
     });
     t.end();


### PR DESCRIPTION
Would you consider relaxing this requirement? 😁 

Certainly it’s good to encourage the use of a typed array here, say through documentation and examples, but I don’t anticipate the implementation would *require* that is the input is a typed array (e.g., I don’t think we’d need to call *coords*.subarray). So it seems reasonable to allow anything array-like as input.

In particular, it’s nice if you already have a flat plain array [x0, y0, x1, y1, …] from some other library, and you aren’t forced to copy that array into a Float64Array to compute the Delaunay triangulation.