### PR TITLE
Fix rare race condition that produces corrupt halfedges structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "node -r esm test.js",
     "bench": "node -r esm bench.js",
     "build": "rollup -c",
+    "start": "rollup -cw",
     "prepublishOnly": "npm test && npm build"
   },
   "files": [

--- a/test.js
+++ b/test.js
@@ -43,6 +43,10 @@ test('issue #11', (t) => {
     testHalfedges(t, [[516, 661], [369, 793], [426, 539], [273, 525], [204, 694], [747, 750], [454, 390]]);
 });
 
+test('issue #24', (t) => {
+    testHalfedges(t, [[382, 302], [382, 328], [382, 205], [623, 175], [382, 188], [382, 284], [623, 87], [623, 341], [141, 227]]);
+});
+
 function testHalfedges(t, points) {
     const d = Delaunator.from(points);
     for (let i = 0; i < d.halfedges.length; i++) {


### PR DESCRIPTION
Closes #24, and a more robust fix for #11. It's not an elegant fix, but since the condition happens pretty rarely, it shouldn't affect performance. 

I've also added a crude ASCII illustration to code comments so that I don't forget what's going on in the `_legalize` routine again.

cc @mbostock @redblobgames 