### PR TITLE
Lint docs code with the same config as source

### DIFF
--- a/docs/diagrams.js
+++ b/docs/diagrams.js
@@ -12,8 +12,10 @@
 
 */
 
+/* global Delaunator, triangleCenter, forEachTriangle, forEachTriangleEdge, forEachVoronoiCell, edgesAroundPoint, nextHalfedge */
+
 /* points1 = new Poisson([1000, 1000], 70, undefined, undefined, Math.random).fill() */
-const points1 = [[338,601],[357,469],[200,583],[424,634],[302,516],[265,650],[459,570],[367,723],[453,454],[220,472],[326,367],[424,369],[393,544],[121,661],[180,704],[126,516],[87,588],[523,614],[472,730],[277,751],[585,554],[532,497],[351,835],[450,819],[511,377],[586,429],[251,396],[164,416],[224,322],[299,238],[404,275],[470,315],[121,762],[2,630],[21,699],[186,828],[40,412],[28,496],[572,699],[646,616],[566,811],[275,856],[622,493],[720,565],[382,945],[257,933],[475,895],[554,890],[512,255],[627,367],[570,314],[712,448],[126,337],[122,265],[212,216],[397,183],[326,154],[35,833],[117,848],[145,935],[58,296],[652,769],[653,686],[770,664],[628,884],[697,846],[816,549],[454,980],[586,971],[670,968],[508,119],[573,179],[697,247],[755,324],[625,264],[783,442],[73,178],[142,186],[188,123],[408,98],[318,68],[21,948],[9,207],[782,761],[717,730],[854,729],[894,659],[741,916],[815,896],[884,580],[856,416],[898,511],[804,996],[599,69],[472,10],[665,138],[821,232],[775,147],[884,279],[98,53],[17,94],[208,28],[381,5],[91,980],[836,811],[918,766],[974,706],[900,843],[962,580],[939,930],[874,969],[970,492],[958,327],[938,405],[567,0],[700,16],[910,184],[863,106],[956,248],[780,21],[890,354],[987,801],[979,96],[742,82],[917,44],[853,14],[986,876],[986,171],[980,11]];
+const points1 = [[338, 601], [357, 469], [200, 583], [424, 634], [302, 516], [265, 650], [459, 570], [367, 723], [453, 454], [220, 472], [326, 367], [424, 369], [393, 544], [121, 661], [180, 704], [126, 516], [87, 588], [523, 614], [472, 730], [277, 751], [585, 554], [532, 497], [351, 835], [450, 819], [511, 377], [586, 429], [251, 396], [164, 416], [224, 322], [299, 238], [404, 275], [470, 315], [121, 762], [2, 630], [21, 699], [186, 828], [40, 412], [28, 496], [572, 699], [646, 616], [566, 811], [275, 856], [622, 493], [720, 565], [382, 945], [257, 933], [475, 895], [554, 890], [512, 255], [627, 367], [570, 314], [712, 448], [126, 337], [122, 265], [212, 216], [397, 183], [326, 154], [35, 833], [117, 848], [145, 935], [58, 296], [652, 769], [653, 686], [770, 664], [628, 884], [697, 846], [816, 549], [454, 980], [586, 971], [670, 968], [508, 119], [573, 179], [697, 247], [755, 324], [625, 264], [783, 442], [73, 178], [142, 186], [188, 123], [408, 98], [318, 68], [21, 948], [9, 207], [782, 761], [717, 730], [854, 729], [894, 659], [741, 916], [815, 896], [884, 580], [856, 416], [898, 511], [804, 996], [599, 69], [472, 10], [665, 138], [821, 232], [775, 147], [884, 279], [98, 53], [17, 94], [208, 28], [381, 5], [91, 980], [836, 811], [918, 766], [974, 706], [900, 843], [962, 580], [939, 930], [874, 969], [970, 492], [958, 327], [938, 405], [567, 0], [700, 16], [910, 184], [863, 106], [956, 248], [780, 21], [890, 354], [987, 801], [979, 96], [742, 82], [917, 44], [853, 14], [986, 876], [986, 171], [980, 11]];
 const points2 = [[320, 170], [400, 270], [220, 270], [530, 50], [100, 80], [300, 30]];
 
 const delaunay1 = Delaunator.from(points1);
@@ -21,93 +23,95 @@ const delaunay2 = Delaunator.from(points2);
 
 
 function tangent(a, b) {
-    let dx = b[0] - a[0], dy = b[1] - a[1];
-    let d = Math.sqrt(dx*dx + dy*dy);
-    return [dx/d, dy/d];
+    const dx = b[0] - a[0];
+    const dy = b[1] - a[1];
+    const d = Math.sqrt(dx * dx + dy * dy);
+    return [dx / d, dy / d];
 }
 
 function normal(a, b) {
-    let dx = b[0] - a[0], dy = b[1] - a[1];
-    let d = Math.sqrt(dx*dx + dy*dy);
-    return [dy/d, -dx/d];
+    const dx = b[0] - a[0];
+    const dy = b[1] - a[1];
+    const d = Math.sqrt(dx * dx + dy * dy);
+    return [dy / d, -dx / d];
 }
 
 
 function redPointsSvg(points) {
-    let results = [`<g class="seed-points">`];
+    const results = ['<g class="seed-points">'];
     for (let i = 0; i < points.length; i++) {
-        let p = points[i];
+        const p = points[i];
         results.push(`<circle class="point-${i}" cx="${p[0]}" cy="${p[1]}" r="5"/>`);
     }
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
 function bluePointsSvg(points, delaunay) {
-    let results = [`<g class="vertices">`];
+    const results = ['<g class="vertices">'];
     for (let t = 0; t < delaunay.triangles.length / 3; t++) {
-        let point = triangleCenter(points, delaunay, t);
+        const point = triangleCenter(points, delaunay, t);
         results.push(`<circle cx="${point[0]}" cy="${point[1]}" r="3" fill="hsl(240,50%,50%)"/>`);
     }
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
 function delaunaySvg(points, delaunay) {
-    let results = [`<g class="edges">`];
+    const results = ['<g class="edges">'];
     forEachTriangleEdge(points, delaunay, (e, p, q) => {
         results.push(`<line x1="${p[0]}" y1="${p[1]}" x2="${q[0]}" y2="${q[1]}" />`);
     });
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
-function trianglesSvg(points, delaunay, fill=(t)=>"white") {
-    let results = [`<g class="delaunay-draw">`];
+function trianglesSvg(points, delaunay, fill = () => 'white') {
+    const results = ['<g class="delaunay-draw">'];
     forEachTriangle(points, delaunay, (t, p) => {
         results.push(`<polygon data-id="${t}" points="${p}" fill="${fill(t)}"/>`);
     });
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
 function voronoiSvg(points, delaunay) {
-    let results = [`<g class="edges">`];
+    const results = ['<g class="edges">'];
     for (let e = 0; e < delaunay.halfedges.length; e++) {
         if (e < delaunay.halfedges[e]) {
-            let a = triangleCenter(points, delaunay, Math.floor(e / 3)),
-                b = triangleCenter(points, delaunay, Math.floor(delaunay.halfedges[e] / 3));
+            const a = triangleCenter(points, delaunay, Math.floor(e / 3));
+            const b = triangleCenter(points, delaunay, Math.floor(delaunay.halfedges[e] / 3));
             results.push(`<line x1="${a[0]}" y1="${a[1]}" x2="${b[0]}" y2="${b[1]}"/>`);
         }
     }
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
 function cellsSvg(points, delaunay) {
-    let results = [`<g class="voronoi-draw">`];
+    const results = ['<g class="voronoi-draw">'];
     forEachVoronoiCell(points, delaunay, (p, vertices) => {
-        let hue = (2*p) % 360;
+        const hue = (2 * p) % 360;
         results.push(`<polygon data-id="${p}" points="${vertices}" fill="hsl(${hue},20%,50%)"/>`);
     });
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
-function halfedgeSvg(points, delaunay, filter=()=>true) {
+function halfedgeSvg(points, delaunay, filter = () => true) {
     const dn = 4, dt = 15;
-    let results = [`<g class="edges arrowhead">`];
+    const results = ['<g class="edges arrowhead">'];
     for (let e1 = 0; e1 < delaunay.halfedges.length; e1++) {
         if (!filter(e1)) { continue; }
-        let e2 = nextHalfedge(e1);
-        let a = points[delaunay.triangles[e1]],
-            b = points[delaunay.triangles[e2]],
-            n = normal(a, b),
-            t = tangent(a, b);
-        results.push(`<line class="edge-${e1}" x1="${a[0]+dn*n[0]+dt*t[0]}" y1="${a[1]+dn*n[1]+dt*t[1]}" x2="${b[0]+dn*n[0]-dt*t[0]}" y2="${b[1]+dn*n[1]-dt*t[1]}" />`);
+        const e2 = nextHalfedge(e1);
+        const a = points[delaunay.triangles[e1]];
+        const b = points[delaunay.triangles[e2]];
+        const n = normal(a, b);
+        const t = tangent(a, b);
+        results.push(`<line class="edge-${e1}" x1="${a[0] + dn * n[0] + dt * t[0]}" y1="${a[1] + dn * n[1] + dt * t[1]}" x2="${b[0] + dn * n[0] - dt * t[0]}" y2="${b[1] + dn * n[1] - dt * t[1]}" />`);
     }
-    results.push(`</g>`);
-    return results.join("");
+    results.push('</g>');
+    return results.join('');
 }
 
 const $ = document.querySelector.bind(document);
@@ -185,11 +189,11 @@ Step: <input type=range value=0 min=0 max=9 oninput="updateCirculation()">
 <figcaption>Circulate around point</figcaption>
 </figure>`;
 function updateCirculation() {
-    const slider = $("#diagram-circulate input");
-    let incoming = edgesAroundPoint(delaunay2, 2);
-    let outgoing = incoming.map(e => nextHalfedge(e));
-    let step = slider.valueAsNumber;
-    let edge = step%2 === 0? incoming[step/2] : outgoing[(step-1)/2];
-    $("#diagram-circulate .highlight").innerHTML = halfedgeSvg(points2, delaunay2, e => e === edge);
+    const slider = $('#diagram-circulate input');
+    const incoming = edgesAroundPoint(delaunay2, 2);
+    const outgoing = incoming.map(e => nextHalfedge(e));
+    const step = slider.valueAsNumber;
+    const edge = step % 2 === 0 ? incoming[step / 2] : outgoing[(step - 1) / 2];
+    $('#diagram-circulate .highlight').innerHTML = halfedgeSvg(points2, delaunay2, e => e === edge);
 }
 updateCirculation();

--- a/docs/index.html
+++ b/docs/index.html
@@ -126,8 +126,8 @@
     </p>
 
     <script>
-function edgesOfTriangle(t) { return [3*t, 3*t+1, 3*t+2]; }
-function triangleOfEdge(e)  { return Math.floor(e/3); }
+function edgesOfTriangle(t) { return [3 * t, 3 * t + 1, 3 * t + 2]; }
+function triangleOfEdge(e)  { return Math.floor(e / 3); }
     </script>
 
     <p id="edge-to-edges">
@@ -135,8 +135,8 @@ function triangleOfEdge(e)  { return Math.floor(e/3); }
     </p>
 
     <script>
-function nextHalfedge(e) { return (e % 3 === 2) ? e-2 : e+1; }
-function prevHalfedge(e) { return (e % 3 === 0) ? e+2 : e-1; }
+function nextHalfedge(e) { return (e % 3 === 2) ? e - 2 : e + 1; }
+function prevHalfedge(e) { return (e % 3 === 0) ? e + 2 : e - 1; }
     </script>
 
     <p>
@@ -153,8 +153,8 @@ function prevHalfedge(e) { return (e % 3 === 0) ? e+2 : e-1; }
 function forEachTriangleEdge(points, delaunay, callback) {
     for (let e = 0; e < delaunay.triangles.length; e++) {
         if (e > delaunay.halfedges[e]) {
-            let p = points[delaunay.triangles[e]];
-            let q = points[delaunay.triangles[nextHalfedge(e)]];
+            const p = points[delaunay.triangles[e]];
+            const q = points[delaunay.triangles[nextHalfedge(e)]];
             callback(e, p, q);
         }
     }
@@ -170,11 +170,11 @@ function forEachTriangleEdge(points, delaunay, callback) {
     </p>
 
     <script id="triangle-to-points">
-function edgesOfTriangle(t) { return [3*t, 3*t+1, 3*t+2]; }
+function edgesOfTriangle(t) { return [3 * t, 3 * t + 1, 3 * t + 2]; }
 
 function pointsOfTriangle(delaunay, t) {
     return edgesOfTriangle(t)
-           .map(e => delaunay.triangles[e]);
+        .map(e => delaunay.triangles[e]);
 }
 
 function forEachTriangle(points, delaunay, callback) {
@@ -193,12 +193,12 @@ function forEachTriangle(points, delaunay, callback) {
     </p>
 
     <script id="triangle-to-triangles">
-function triangleOfEdge(e)  { return Math.floor(e/3); }
+function triangleOfEdge(e)  { return Math.floor(e / 3); }
 
 function trianglesAdjacentToTriangle(delaunay, t) {
-    let adjacentTriangles = [];
-    for (let e of edgesOfTriangle(t)) {
-        let opposite = delaunay.halfedges[e];
+    const adjacentTriangles = [];
+    for (const e of edgesOfTriangle(t)) {
+        const opposite = delaunay.halfedges[e];
         if (opposite >= 0) {
             adjacentTriangles.push(triangleOfEdge(opposite));
         }
@@ -227,13 +227,13 @@ function trianglesAdjacentToTriangle(delaunay, t) {
 
     <script>
 function circumcenter(a, b, c) {
-    let ad = a[0]*a[0] + a[1]*a[1],
-        bd = b[0]*b[0] + b[1]*b[1],
-        cd = c[0]*c[0] + c[1]*c[1];
-    let D = 2 * (a[0] * (b[1] - c[1]) + b[0] * (c[1] - a[1]) + c[0] * (a[1] - b[1]));
+    const ad = a[0] * a[0] + a[1] * a[1];
+    const bd = b[0] * b[0] + b[1] * b[1];
+    const cd = c[0] * c[0] + c[1] * c[1];
+    const D = 2 * (a[0] * (b[1] - c[1]) + b[0] * (c[1] - a[1]) + c[0] * (a[1] - b[1]));
     return [
-      1/D * (ad * (b[1] - c[1]) + bd * (c[1] - a[1]) + cd * (a[1] - b[1])),
-      1/D * (ad * (c[0] - b[0]) + bd * (a[0] - c[0]) + cd * (b[0] - a[0])),
+        1 / D * (ad * (b[1] - c[1]) + bd * (c[1] - a[1]) + cd * (a[1] - b[1])),
+        1 / D * (ad * (c[0] - b[0]) + bd * (a[0] - c[0]) + cd * (b[0] - a[0])),
     ];
 }
     </script>
@@ -246,8 +246,8 @@ function circumcenter(a, b, c) {
 
     <script>
 function triangleCenter(points, delaunay, t) {
-  let vertices = pointsOfTriangle(delaunay, t).map(p => points[p]);
-  return circumcenter(vertices[0], vertices[1], vertices[2]);
+    const vertices = pointsOfTriangle(delaunay, t).map(p => points[p]);
+    return circumcenter(vertices[0], vertices[1], vertices[2]);
 }
     </script>
 
@@ -261,8 +261,8 @@ function triangleCenter(points, delaunay, t) {
 function forEachVoronoiEdge(points, delaunay, callback) {
     for (let e = 0; e < delaunay.triangles.length; e++) {
         if (e < delaunay.halfedges[e]) {
-            let p = triangleCenter(points, delaunay, triangleOfEdge(e));
-            let q = triangleCenter(points, delaunay, triangleOfEdge(delaunay.halfedges[e]));
+            const p = triangleCenter(points, delaunay, triangleOfEdge(e));
+            const q = triangleCenter(points, delaunay, triangleOfEdge(delaunay.halfedges[e]));
             callback(e, p, q);
         }
     }
@@ -286,11 +286,11 @@ function forEachVoronoiEdge(points, delaunay, callback) {
 
     <script>
 function edgesAroundPoint(delaunay, start) {
-    let result = [];
+    const result = [];
     let incoming = start;
     do {
         result.push(incoming);
-        let outgoing = nextHalfedge(incoming);
+        const outgoing = nextHalfedge(incoming);
         incoming = delaunay.halfedges[outgoing];
     } while (incoming !== -1 && incoming !== start);
     return result;
@@ -309,14 +309,14 @@ function edgesAroundPoint(delaunay, start) {
 
     <script>
 function forEachVoronoiCell(points, delaunay, callback) {
-    let seen = new Set();  // of point ids
+    const seen = new Set();  // of point ids
     for (let e = 0; e < delaunay.triangles.length; e++) {
-        let p = delaunay.triangles[nextHalfedge(e)];
+        const p = delaunay.triangles[nextHalfedge(e)];
         if (!seen.has(p)) {
             seen.add(p);
-            let edges = edgesAroundPoint(delaunay, e);
-            let triangles = edges.map(triangleOfEdge);
-            let vertices = triangles.map(t => triangleCenter(points, delaunay, t));
+            const edges = edgesAroundPoint(delaunay, e);
+            const triangles = edges.map(triangleOfEdge);
+            const vertices = triangles.map(t => triangleCenter(points, delaunay, t));
             callback(p, vertices);
         }
     }
@@ -352,18 +352,18 @@ function forEachVoronoiCell(points, delaunay, callback) {
 
     <script>
 function forEachVoronoiCell(points, delaunay, callback) {
-    let index = new Map(); // point id to half-edge id
+    const index = new Map(); // point id to half-edge id
     for (let e = 0; e < delaunay.triangles.length; e++) {
-        let endpoint = delaunay.triangles[nextHalfedge(e)];
+        const endpoint = delaunay.triangles[nextHalfedge(e)];
         if (!index.has(endpoint) || delaunay.halfedges[e] === -1) {
             index.set(endpoint, e);
         }
     }
     for (let p = 0; p < points.length; p++) {
-        let incoming = index.get(p);
-        let edges = edgesAroundPoint(delaunay, incoming);
-        let triangles = edges.map(triangleOfEdge);
-        let vertices = triangles.map(t => triangleCenter(points, delaunay, t));
+        const incoming = index.get(p);
+        const edges = edgesAroundPoint(delaunay, incoming);
+        const triangles = edges.map(triangleOfEdge);
+        const vertices = triangles.map(t => triangleCenter(points, delaunay, t));
         callback(p, vertices);
     }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/mapbox/delaunator.git"
   },
   "scripts": {
-    "lint": "eslint index.js test.js bench.js rollup.config.js",
+    "lint": "eslint index.js test.js bench.js rollup.config.js docs/diagrams.js",
     "pretest": "npm run lint",
     "test": "node -r esm test.js",
     "bench": "node -r esm bench.js",
@@ -35,14 +35,7 @@
     "delaunator.min.js"
   ],
   "eslintConfig": {
-    "extends": "mourner",
-    "parserOptions": {
-      "sourceType": "module"
-    },
-    "rules": {
-      "no-var": "error",
-      "prefer-const": "error"
-    }
+    "extends": "mourner"
   },
   "keywords": [
     "delaunay triangulation",


### PR DESCRIPTION
@redblobgames added linting for the docs files to keep it to the same standard as the source code. I couldn't go all the way though because of our `script { display: block; }` approach.