### PR TITLE
Use flat index arrays for tracking convex hull

### DIFF
--- a/docs/demo.html
+++ b/docs/demo.html
@@ -91,7 +91,6 @@ function draw() {
     ctx.clearRect(0, 0, w, h);
 
     var triangles = delaunay.triangles;
-    var hull = delaunay.hull;
 
     ctx.beginPath();
     for (var i = 0; i < triangles.length; i += 3) {
@@ -110,12 +109,10 @@ function draw() {
     // ctx.fill();
 
     ctx.beginPath();
-    ctx.moveTo(getX(hull.i), getY(hull.i));
-    var e = hull;
-    do {
-        ctx.lineTo(getX(e.next.i), getY(e.next.i));
-        e = e.next;
-    } while (e !== hull);
+    for (const i of delaunay.hull) {
+        ctx.lineTo(getX(i), getY(i));
+    }
+    ctx.closePath();
     ctx.lineWidth = 1;
     ctx.strokeStyle = 'red';
     ctx.stroke();

--- a/index.js
+++ b/index.js
@@ -132,9 +132,9 @@ export default class Delaunator {
         hullTri[i1] = 1;
         hullTri[i2] = 2;
 
-        this._hashEdge(i0);
-        this._hashEdge(i1);
-        this._hashEdge(i2);
+        this._hash[this._hashKey(i0x, i0y)] = i0;
+        this._hash[this._hashKey(i1x, i1y)] = i1;
+        this._hash[this._hashKey(i2x, i2y)] = i2;
 
         const maxTriangles = 2 * n - 5;
         const triangles = this.triangles = new Uint32Array(maxTriangles * 3);
@@ -211,8 +211,8 @@ export default class Delaunator {
             hullNext[i] = n;
 
             // save the two new edges in the hash table
-            this._hashEdge(i);
-            this._hashEdge(e);
+            this._hash[this._hashKey(x, y)] = i;
+            this._hash[this._hashKey(coords[2 * e], coords[2 * e + 1])] = e;
         }
 
         this.hull = new Uint32Array(hullSize);
@@ -225,10 +225,6 @@ export default class Delaunator {
         // trim typed triangle mesh arrays
         this.triangles = triangles.subarray(0, this.trianglesLen);
         this.halfedges = halfedges.subarray(0, this.trianglesLen);
-    }
-
-    _hashEdge(i) {
-        this._hash[this._hashKey(this.coords[2 * i], this.coords[2 * i + 1])] = i;
     }
 
     _hashKey(x, y) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,10 @@
     "delaunator.min.js"
   ],
   "eslintConfig": {
-    "extends": "mourner"
+    "extends": "mourner",
+    "rules": {
+      "no-sequences": 0
+    }
   },
   "keywords": [
     "delaunay triangulation",

--- a/test.js
+++ b/test.js
@@ -99,14 +99,11 @@ function validate(t, points) {
 
     // validate triangulation
     const hullAreas = [];
-    let e = d.hull;
-    do {
-        const [x0, y0] = points[e.prev.i];
-        const [x, y] = points[e.i];
+    for (let i = 0, len = d.hull.length, j = len - 1; i < len; j = i++) {
+        const [x0, y0] = points[d.hull[j]];
+        const [x, y] = points[d.hull[i]];
         hullAreas.push((x - x0) * (y + y0));
-        e = e.next;
-    } while (e !== d.hull);
-
+    }
     const hullArea = sum(hullAreas);
 
     const triangleAreas = [];


### PR DESCRIPTION
This makes Delaunator faster on cases where the convex hull grows big by avoiding GC churn, which happens because of constant allocation/removal of hull nodes during the algorithm. E.g. degenerate 1 million case went from 720ms to 460ms (and a 10 million degenerate one no longer crashes with out-of-memory error).

The code also becomes easier to port to other languages like Rust because we no longer use object pointers.

As a side effect, instead of using a linked list for the hull, the PR exposes it as a typed array of indices, which is easier to work with, although a breaking change.

A potential drawback might be the need to allocate `Uint32Array(3 * n)` additional memory at the beginning to track the hull, but this should have a negligible effect.

@mbostock @fogleman @delfrrr what do you think?