### PR TITLE
Subheader+list increases projects/ports visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,16 @@ An incredibly fast JavaScript library for
 - [Interactive Demo](https://mapbox.github.io/delaunator/demo.html)
 - [Guide to data structures](https://mapbox.github.io/delaunator/)
 
-Projects based on Delaunator:
+### Projects based on Delaunator
 
 - [d3-delaunay](https://github.com/d3/d3-delaunay) for Voronoi diagrams, search, traversal and rendering.
 - [d3-geo-voronoi](https://github.com/Fil/d3-geo-voronoi) for Delaunay triangulations and Voronoi diagrams on a sphere (e.g. for geographic locations).
 
-Ports to other languages:
-[delaunator-rs](https://github.com/mourner/delaunator-rs) (Rust),
-[fogleman/delaunay](https://github.com/fogleman/delaunay) (Go),
-[delaunator-cpp](https://github.com/delfrrr/delaunator-cpp) (C++).
+### Ports to other languages
+
+- [delaunator-rs](https://github.com/mourner/delaunator-rs) (Rust)
+- [fogleman/delaunay](https://github.com/fogleman/delaunay) (Go)
+- [delaunator-cpp](https://github.com/delfrrr/delaunator-cpp) (C++)
 
 <img src="delaunator.png" alt="Delaunay triangulation example" width="600" />
 


### PR DESCRIPTION
See #38.

Slight reformatting to make it less likely that idiots like me read over the section that mentions other projects and ports ports.