### PR TITLE
Mark the package as having no side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "module": "index.js",
   "jsdelivr": "delaunator.min.js",
   "unpkg": "delaunator.min.js",
+  "sideEffects": false,
   "dependencies": {},
   "devDependencies": {
     "c8": "^5.0.1",


### PR DESCRIPTION
This helps Rollup and webpack to perform tree shaking, by telling them they can skip the whole module if its exports are not used.