### PR TITLE
guide - handle duplicate points in forEachVoronoiCell

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -363,6 +363,7 @@ function forEachVoronoiCell(points, delaunay, callback) {
         }
     }
     for (let p = 0; p < points.length; p++) {
+        if (!index.has(p)) { continue; } // no cell was made for this point
         const incoming = index.get(p);
         const edges = edgesAroundPoint(delaunay, incoming);
         const triangles = edges.map(triangleOfEdge);


### PR DESCRIPTION
Duplicate points are skipped in Delaunator, so there will be no triangle edge pointing to it, and it won't exist in the index in this function. Skip that point because it has no voronoi cell, and the purpose of the function is to iterate over the voronoi cells. Fixes #85 